### PR TITLE
Copyright headers: nv-reason-cxr, nv-segment-ct, nv-segment-ctmr

### DIFF
--- a/skills/nv-reason-cxr/scripts/run_nv_reason_cxr.py
+++ b/skills/nv-reason-cxr/scripts/run_nv_reason_cxr.py
@@ -1,10 +1,26 @@
 #!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 """Run NV-Reason-CXR-3B inference on a PNG/JPEG chest X-ray image.
 
 The live path follows the upstream Hugging Face Transformers example.
 The mock path exists for CI and evidence-pack wiring checks; it never calls
 the model and should not be treated as clinical or model output.
 """
+
 from __future__ import annotations
 
 import argparse
@@ -169,8 +185,7 @@ def _setup_report(model_id: str) -> dict:
     missing_required = [
         name
         for name in ("torch", "transformers", "Pillow")
-        if not dependencies[name].get("installed")
-        or not dependencies[name].get("importable", True)
+        if not dependencies[name].get("installed") or not dependencies[name].get("importable", True)
     ]
     if missing_required:
         recommendation = "install_required_dependencies"
@@ -208,7 +223,7 @@ def _png_info(path: Path) -> tuple[int, int]:
         header = f.read(int("24"))
     if len(header) < int("24") or not header.startswith(b"\x89PNG\r\n\x1a\n"):
         raise SkillError(f"unsupported image format for {path}: expected PNG or JPEG")
-    width, height = struct.unpack(">II", header[int("16"):int("24")])
+    width, height = struct.unpack(">II", header[int("16") : int("24")])
     if width <= 0 or height <= 0:
         raise SkillError(f"invalid PNG dimensions for {path}: {width}x{height}")
     return width, height
@@ -312,9 +327,13 @@ def _write_synthetic_png(path: Path, *, width: int = int("96"), height: int = in
                 curve_y = height * float("0.22") + rib * float("7.0") + float("9.0") * (xn**2)
                 if abs(y - curve_y) < float("0.75") and float("0.12") < abs(xn) < float("0.9"):
                     value = max(value, int("132"))
-            if (x - width * float("0.5")) ** 2 + (y - height * float("0.88")) ** 2 < (width * float("0.1")) ** 2:
+            if (x - width * float("0.5")) ** 2 + (y - height * float("0.88")) ** 2 < (
+                width * float("0.1")
+            ) ** 2:
                 value = max(value, int("112"))
-            vignette = int(int("22") * math.sqrt(xn**2 + ((y - height * float("0.5")) / height) ** 2))
+            vignette = int(
+                int("22") * math.sqrt(xn**2 + ((y - height * float("0.5")) / height) ** 2)
+            )
             value = max(0, min(int("255"), value - vignette))
             rows.extend([value, value, value])
 
@@ -513,8 +532,7 @@ def _run_transformers_inference(
         with torch.inference_mode():
             generated_ids = model.generate(**inputs, max_new_tokens=max_new_tokens)
         trimmed_ids = [
-            out_ids[len(in_ids) :]
-            for in_ids, out_ids in zip(inputs.input_ids, generated_ids)
+            out_ids[len(in_ids) :] for in_ids, out_ids in zip(inputs.input_ids, generated_ids)
         ]
         generated_tokens = int(trimmed_ids[0].shape[-1]) if trimmed_ids else 0
         generated_text = processor.batch_decode(
@@ -594,7 +612,9 @@ def main(argv: list[str] | None = None) -> int:
             print(json.dumps(_setup_report(args.model_id), indent=2, sort_keys=True))
             return 0
         if args.image_or_fixture is None:
-            print("error: image_or_fixture is required unless --check-setup is used", file=sys.stderr)
+            print(
+                "error: image_or_fixture is required unless --check-setup is used", file=sys.stderr
+            )
             return 2
 
         out_dir = args.out_dir.resolve()

--- a/skills/nv-reason-cxr/skill_manifest.yaml
+++ b/skills/nv-reason-cxr/skill_manifest.yaml
@@ -1,3 +1,18 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 id: medagent.nv_reason_cxr
 version: 0.1.0
 license: Apache-2.0

--- a/skills/nv-reason-cxr/tests/test_nv_reason_cxr.py
+++ b/skills/nv-reason-cxr/tests/test_nv_reason_cxr.py
@@ -1,8 +1,24 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 """Smoke tests for the NV-Reason-CXR skill wrapper.
 
 These tests verify input handling, mock-mode output, and clean error paths.
 They do not download or run the NV-Reason-CXR model.
 """
+
 from __future__ import annotations
 
 import json

--- a/skills/nv-segment-ct/fixtures/fetch_spleen_fixture.py
+++ b/skills/nv-segment-ct/fixtures/fetch_spleen_fixture.py
@@ -1,4 +1,19 @@
 #!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 """Fetch the spleen_03 fixture from the Decathlon MSD09 dataset.
 
 The committed Medical AI Skills tree does not ship `spleen_03.nii.gz` (it is a
@@ -20,11 +35,11 @@ Idempotent: skips the download if the fixture is already present, and
 skips the extraction if Task09_Spleen.tar already lives in
 .workbench_data/datasets/.
 """
+
 from __future__ import annotations
 
 import argparse
 import shutil
-import subprocess
 import sys
 import tarfile
 import urllib.request
@@ -68,7 +83,9 @@ def _download(url: str, dest: Path) -> None:
                     sys.stderr.write(f"[fetch]   {_human(n)}/{_human(total) if total else '?'}\n")
                     last_report = n
     tmp.rename(dest)
-    sys.stderr.write(f"[fetch] saved {_human(dest.stat().st_size)} to {dest.relative_to(REPO_ROOT)}\n")
+    sys.stderr.write(
+        f"[fetch] saved {_human(dest.stat().st_size)} to {dest.relative_to(REPO_ROOT)}\n"
+    )
 
 
 def _extract_case(tar_path: Path, dest_dir: Path, member_name: str) -> Path:
@@ -88,13 +105,16 @@ def _extract_case(tar_path: Path, dest_dir: Path, member_name: str) -> Path:
 def main(argv: list[str] | None = None) -> int:
     ap = argparse.ArgumentParser(description=__doc__.splitlines()[0])
     ap.add_argument(
-        "--keep-tar", action="store_true",
+        "--keep-tar",
+        action="store_true",
         help="Keep the 1.5 GB Task09_Spleen.tar after extraction (default: keep)",
     )
-    args = ap.parse_args(argv)
+    ap.parse_args(argv)
 
     if FIXTURE_DEST.is_file():
-        sys.stderr.write(f"[fetch] fixture already present: {FIXTURE_DEST.relative_to(REPO_ROOT)}\n")
+        sys.stderr.write(
+            f"[fetch] fixture already present: {FIXTURE_DEST.relative_to(REPO_ROOT)}\n"
+        )
         return 0
 
     if not TASK09_TAR.is_file():
@@ -105,7 +125,9 @@ def main(argv: list[str] | None = None) -> int:
     if not (TASK09_EXTRACT / SOURCE_CASE).is_file():
         _extract_case(TASK09_TAR, DATASETS_DIR, SOURCE_CASE)
     else:
-        sys.stderr.write(f"[fetch] case already extracted: {(TASK09_EXTRACT / SOURCE_CASE).relative_to(REPO_ROOT)}\n")
+        sys.stderr.write(
+            f"[fetch] case already extracted: {(TASK09_EXTRACT / SOURCE_CASE).relative_to(REPO_ROOT)}\n"
+        )
 
     src = TASK09_EXTRACT / SOURCE_CASE
     FIXTURE_DEST.parent.mkdir(parents=True, exist_ok=True)

--- a/skills/nv-segment-ct/fixtures/generate_preflight_fixture.py
+++ b/skills/nv-segment-ct/fixtures/generate_preflight_fixture.py
@@ -1,4 +1,19 @@
 #!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 """Generate a tiny synthetic CT NIfTI for repository preflight checks.
 
 The real NV-Segment-CT example fixture (`spleen_03.nii.gz`) is intentionally
@@ -6,13 +21,13 @@ not committed because it is a medical imaging artifact. This script writes a
 small, synthetic, non-clinical volume that is sufficient for input-boundary
 preflight checks without downloading data or model weights.
 """
+
 from __future__ import annotations
 
 from pathlib import Path
 
 import nibabel as nib
 import numpy as np
-
 
 ROOT = Path(__file__).resolve().parent
 OUT = ROOT / "preflight_synthetic_ct.nii.gz"

--- a/skills/nv-segment-ct/scripts/run_vista3d.py
+++ b/skills/nv-segment-ct/scripts/run_vista3d.py
@@ -1,4 +1,19 @@
 #!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 """NVIDIA-Medtech NV-Segment-CT (VISTA3D) skill.
 
 Thin wrapper around the official `HuggingFacePipelineHelper` from
@@ -9,6 +24,7 @@ NIfTI mask to emit a structured summary.
 
 Engineering verification only. Output is NOT clinically meaningful.
 """
+
 import contextlib
 import json
 import os
@@ -33,6 +49,7 @@ def _stdout_to_stderr():
     finally:
         os.dup2(saved, fd)
         os.close(saved)
+
 
 SKILL_DIR = Path(__file__).resolve().parent.parent
 REPO_ROOT = SKILL_DIR.parent.parent
@@ -93,7 +110,7 @@ def _input_summary(img: nib.spatialimages.SpatialImage) -> dict:
     return {
         "shape": [int(v) for v in img.shape],
         "ndim": len(img.shape),
-        "spacing": _round_floats(zooms[:int("3")]),
+        "spacing": _round_floats(zooms[: int("3")]),
     }
 
 
@@ -103,8 +120,8 @@ def _geometry_summary(
 ) -> dict:
     input_shape = [int(v) for v in input_img.shape]
     output_shape = [int(v) for v in output_img.shape]
-    input_spacing = _round_floats(input_img.header.get_zooms()[:int("3")])
-    output_spacing = _round_floats(output_img.header.get_zooms()[:int("3")])
+    input_spacing = _round_floats(input_img.header.get_zooms()[: int("3")])
+    output_spacing = _round_floats(output_img.header.get_zooms()[: int("3")])
     affine_max_abs_diff = float(np.max(np.abs(input_img.affine - output_img.affine)))
     return {
         "input_shape": input_shape,
@@ -126,7 +143,7 @@ def _mask_summary(
 ) -> dict:
     mask_img = nib.load(str(mask_path))
     arr = np.asarray(mask_img.get_fdata()).astype(np.int64)
-    spacing = mask_img.header.get_zooms()[:int("3")]
+    spacing = mask_img.header.get_zooms()[: int("3")]
     voxel_volume_ml = float(np.prod(spacing)) / float("1000.0")
     unique, counts = np.unique(arr, return_counts=True)
     class_counts: dict[str, int] = {}

--- a/skills/nv-segment-ct/skill_manifest.yaml
+++ b/skills/nv-segment-ct/skill_manifest.yaml
@@ -1,3 +1,18 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 id: medagent.nv_segment_ct
 version: 0.2.0
 upstream_refs:

--- a/skills/nv-segment-ct/tests/test_run_vista3d.py
+++ b/skills/nv-segment-ct/tests/test_run_vista3d.py
@@ -1,3 +1,18 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import importlib.util
 from pathlib import Path
 

--- a/skills/nv-segment-ctmr/scripts/run_ctmr.py
+++ b/skills/nv-segment-ctmr/scripts/run_ctmr.py
@@ -1,4 +1,19 @@
 #!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 """NVIDIA-Medtech NV-Segment-CTMR skill wrapper.
 
 Thin wrapper around the upstream MONAI bundle command documented by
@@ -8,6 +23,7 @@ resulting NIfTI label map as JSON.
 
 Engineering verification only. Output is NOT clinically meaningful.
 """
+
 from __future__ import annotations
 
 import json
@@ -21,7 +37,6 @@ from typing import Any
 import nibabel as nib
 import numpy as np
 import typer
-
 
 app = typer.Typer(add_completion=False)
 
@@ -80,7 +95,7 @@ def _spacing3(img: nib.spatialimages.SpatialImage) -> list[float]:
     zooms = list(img.header.get_zooms())
     while len(zooms) < int("3"):
         zooms.append(1.0)
-    return _round_floats(zooms[:int("3")])
+    return _round_floats(zooms[: int("3")])
 
 
 def _input_summary(img: nib.spatialimages.SpatialImage) -> dict[str, Any]:
@@ -440,7 +455,9 @@ def _resolve_upstream_root(
 @app.command()
 def main(
     nifti_path: Path = typer.Argument(..., exists=True, dir_okay=False),
-    output_dir: Path | None = typer.Option(None, "--output-dir", "-o", help="dir for produced masks"),
+    output_dir: Path | None = typer.Option(
+        None, "--output-dir", "-o", help="dir for produced masks"
+    ),
     modality: str = typer.Option("CT_BODY", "--modality", help="CT_BODY | MRI_BODY | MRI_BRAIN"),
     label_prompts: str | None = typer.Option(
         None,

--- a/skills/nv-segment-ctmr/skill_manifest.yaml
+++ b/skills/nv-segment-ctmr/skill_manifest.yaml
@@ -1,3 +1,18 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 id: medagent.nv_segment_ctmr
 version: 0.1.0
 upstream_refs:

--- a/skills/nv-segment-ctmr/tests/test_run_ctmr.py
+++ b/skills/nv-segment-ctmr/tests/test_run_ctmr.py
@@ -1,3 +1,18 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import importlib.util
 from pathlib import Path
 


### PR DESCRIPTION
Part of the copyright-headers rollout (split from #16 to fit the nvskills-ci 1h cap). Headers + ruff/isort/black on the listed dirs only.