### PR TITLE
Run pre-commit in `make lint` (enforce ruff/black/isort/markdownlint in CI)

### DIFF
--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -65,7 +65,14 @@ jobs:
             "nibabel>=4.0" \
             "pydicom>=2.4,<5" \
             "typer>=0.9" \
-            "pytest>=8.0"
+            "pytest>=8.0" \
+            "pre-commit>=3.5"
+
+      - name: Cache pre-commit hook environments
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/pre-commit
+          key: pre-commit-${{ hashFiles('.pre-commit-config.yaml') }}
 
       - name: Lint repository
         run: make lint

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,7 +23,7 @@
 # C++/CMake/metadata hooks from HoloHub are omitted (not applicable here).
 
 # Bot-generated signing artifacts are committed by svc-nvskills-signing; never touch them.
-exclude: '(\.oms\.sig$|(^|/)(skill-card|BENCHMARK)\.md$)'
+exclude: '(\.oms\.sig$|(^|/)(skill-card|BENCHMARK)\.md$|(^|/)skill_completeness_v1/fixtures/)'
 
 repos:
   # General hygiene (skip generated evidence/fixtures and vendored docs)

--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,7 @@
 # See AGENTS.md and ARCHITECTURE.md for the shape this is converging on.
 
 PYTHON ?= python3
+PRE_COMMIT ?= pre-commit
 SKILL ?= dicom-metadata-extract
 SKILL_DIR := $(subst _,-,$(SKILL))
 FIXTURE ?= skills/$(SKILL_DIR)/fixtures/sample_ct.dcm
@@ -172,6 +173,7 @@ test:
 
 lint:
 	$(PYTHON) -m eval_engine.lint_repo
+	$(PRE_COMMIT) run --all-files
 
 # Add any missing NVIDIA SPDX copyright headers, then bump the year of existing
 # ones to the current year. Auto-corrects in place; safe to run repeatedly.


### PR DESCRIPTION
Integrates the pre-commit hooks into `make lint` so they're enforced in CI (lint-and-test runs `make lint`) — previously they were local-only.

- **Makefile**: `make lint` now runs `pre-commit run --all-files` after `eval_engine.lint_repo` (new `PRE_COMMIT ?= pre-commit` var).
- **lint-and-test.yml**: installs `pre-commit` + caches its hook environments.
- **.pre-commit-config.yaml**: excludes `verifiers/skill_completeness_v1/fixtures/` (the nested test-skill fixtures) from all hooks so black/ruff/etc. leave them pristine — they must stay out of changesets for NVCARPS `detect-changes`.

No `skills/` changes → nvskills-ci skips → merges on `lint-and-test`. `svc-nvskills-signing` artifacts stay in the global pre-commit `exclude`, so the bot is never blocked.

Verified locally: `make lint` green — `eval_engine.lint_repo` (0/0) + all 10 pre-commit hooks pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)