### PR TITLE
Update NVSkills CI request template

### DIFF
--- a/.github/workflows/request-nvskills-ci.yml
+++ b/.github/workflows/request-nvskills-ci.yml
@@ -3,11 +3,14 @@ name: Request NVSkills CI
 on:
   issue_comment:
     types: [created]
+  pull_request:
+    types: [opened, reopened, synchronize, ready_for_review]
   push:
 
 jobs:
   request:
     if: >
+      github.event_name == 'pull_request' ||
       (github.event_name == 'issue_comment' &&
         github.event.issue.pull_request &&
         startsWith(github.event.comment.body, '/nvskills-ci')) ||
@@ -17,6 +20,7 @@ jobs:
     permissions:
       contents: read
       pull-requests: read
+      statuses: read
     uses: NVIDIA/skills/.github/workflows/team-request.yml@main
     secrets:
       NVSKILLS_CI_DISPATCH_TOKEN: ${{ secrets.NVSKILLS_CI_DISPATCH_TOKEN }}


### PR DESCRIPTION
## Summary

- Sync `.github/workflows/request-nvskills-ci.yml` with the current `NVIDIA/skills` request template.
- Run the reusable request workflow for opened, reopened, synchronized, and ready-for-review pull requests.
- Allow the request workflow to read commit statuses.

## Why

This enables the new NVSkills CI PR check to surface validation status and prompt maintainers when skill-related changes need validation or revalidation after a new commit.

## Validation

- Confirmed the local workflow Git blob matches the upstream template blob (`4092d220cc4857d843d8e401ed2c349cf247c929`).
- `actionlint .github/workflows/request-nvskills-ci.yml`
- `make lint`
- `make test` (421 passed)
- `make verify-skills`
- `make verify-negative-fixtures`
- `make verify`

AI-assisted: Created with Codex/GPT at the user's request.
