### PR TITLE
Migrate local publication preflight to SkillEvaluator

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,14 +35,14 @@ B ?=
 COMPARE_OUT ?=
 AUDIT_OUT ?= runs/audit_$(SKILL)
 ACTION ?=
-NV_BASE ?= nv-base
-NV_BASE_OUT ?= /tmp/medical-AI-skills-nvbase
-NV_BASE_FLAGS ?= --no-dedup -c
-NV_BASE_REQUIRE_SKILLSPECTOR ?= 1
+SKILL_EVALUATOR ?= skillevaluator
+SKILL_EVALUATOR_OUT ?= /tmp/medical-AI-skills-skillevaluator
+SKILL_EVALUATOR_REPORTS ?= json,markdown
+SKILL_EVALUATOR_FLAGS ?= --external --no-dedup -c --min-score 70
 
 WORKFLOW_CT_SEG ?= examples/workflows/ct_dicom_to_segmentation_evidence.yaml
 WORKFLOW_CT_SEG_OUT ?= runs/ct_dicom_seg_evidence
-.PHONY: help help-run help-author help-trust help-study help-all run-skill run-llm-skill run-workflow run-workflow-ct-seg run-benchmark run-trusted diff lint test verify verify-skills verify-reproducibility verify-negative-fixtures verify-with-vs-without audit-with-vs-without preflight-with-vs-without transfer-manifest-with-vs-without approval-packet-with-vs-without approved-rerun-plan-with-vs-without invariants-with-vs-without check-invariants-with-vs-without status-agent-skills prove-agent-skills prove-with-vs-without plan-with-vs-without study nv-base-check nv-base-validate validate-skills-internal list-skills compare-skills audit-skill clean-runs validate-pack review-packet validate-skill bench-matrix copyright copyright-check
+.PHONY: help help-run help-author help-trust help-study help-all run-skill run-llm-skill run-workflow run-workflow-ct-seg run-benchmark run-trusted diff lint test verify verify-skills verify-reproducibility verify-negative-fixtures verify-with-vs-without audit-with-vs-without preflight-with-vs-without transfer-manifest-with-vs-without approval-packet-with-vs-without approved-rerun-plan-with-vs-without invariants-with-vs-without check-invariants-with-vs-without status-agent-skills prove-agent-skills prove-with-vs-without plan-with-vs-without study skill-evaluator-check skill-evaluator-validate validate-skills-external nv-base-check nv-base-validate validate-skills-internal list-skills compare-skills audit-skill clean-runs validate-pack review-packet validate-skill bench-matrix copyright copyright-check
 
 help:
 	@echo "Targets:"
@@ -88,9 +88,9 @@ help-all:
 	@echo "  validate-skill SCENARIO=<path> [VALIDATE_SKILL_OUT=<dir>]   paired with/without skill behavior eval (v0: mock backend)"
 	@echo "  verify-skills                                           audit every skill/verifier + repeat reproducibility checks"
 	@echo "  verify-reproducibility                                  run manifest-declared repeat/preflight reproducibility audit"
-	@echo "  nv-base-check                                           verify nv-base is available on PATH or via NV_BASE"
-	@echo "  nv-base-validate [NV_BASE=/path/to/nv-base]             run internal NV-BASE skill profile"
-	@echo "  validate-skills-internal                                alias for nv-base-validate"
+	@echo "  skill-evaluator-check                                   verify the public skillevaluator CLI is available"
+	@echo "  skill-evaluator-validate [SKILL_EVALUATOR=/path/to/skillevaluator]   run the public external publication preflight"
+	@echo "  validate-skills-external                                alias for skill-evaluator-validate"
 	@echo "  --- Trust ---"
 	@echo "  verify                                                  smoke-test evidence harness (lint + canonical pack diff)"
 	@echo "  verify-negative-fixtures                                run every manifest-declared negative fixture"
@@ -118,6 +118,10 @@ help-all:
 	@echo "  lint                                                    structural + doc lints"
 	@echo "  test                                                    pytest (eval_engine + skills + verifiers + with-vs-without harness)"
 	@echo "  clean-runs                                              remove local generated runs"
+	@echo "  --- Deprecated compatibility aliases ---"
+	@echo "  nv-base-check                                           deprecated alias for skill-evaluator-check"
+	@echo "  nv-base-validate                                        deprecated alias for skill-evaluator-validate"
+	@echo "  validate-skills-internal                                deprecated alias for skill-evaluator-validate"
 
 help-run:
 	@echo "Run targets:"
@@ -134,9 +138,10 @@ help-author:
 	@echo "  validate-skill SCENARIO=<path> [VALIDATE_SKILL_OUT=<dir>]   paired with/without skill behavior eval (v0: mock backend)"
 	@echo "  verify-skills                                           audit every skill/verifier + repeat reproducibility checks"
 	@echo "  verify-reproducibility                                  run manifest-declared repeat/preflight reproducibility audit"
-	@echo "  nv-base-check                                           verify nv-base is available on PATH or via NV_BASE"
-	@echo "  nv-base-validate [NV_BASE=/path/to/nv-base]             run internal NV-BASE skill profile"
-	@echo "  validate-skills-internal                                alias for nv-base-validate"
+	@echo "  skill-evaluator-check                                   verify the public skillevaluator CLI is available"
+	@echo "  skill-evaluator-validate [SKILL_EVALUATOR=/path/to/skillevaluator]   run the public external publication preflight"
+	@echo "  validate-skills-external                                alias for skill-evaluator-validate"
+	@echo "  nv-base-validate                                        deprecated compatibility alias"
 	@echo "  list-skills                                             regenerate SKILL_INDEX.md"
 	@echo "  lint                                                    structural + doc lints"
 	@echo "  test                                                    pytest (eval_engine + skills + verifiers + with-vs-without harness)"
@@ -309,33 +314,37 @@ prove-with-vs-without:
 plan-with-vs-without:
 	@$(PYTHON) tools/with_vs_without/audit_nv_model_studies.py --format commands
 
+skill-evaluator-check:
+	@if ! command -v "$(SKILL_EVALUATOR)" >/dev/null 2>&1; then \
+		echo "skillevaluator command not found: $(SKILL_EVALUATOR)"; \
+		echo "Install the public release (https://docs.nvidia.com/skills/skillevaluator/installation), or run:"; \
+		echo "  make skill-evaluator-validate SKILL_EVALUATOR=/path/to/skillevaluator"; \
+		exit 127; \
+	fi
+	@skill_evaluator_path="$$(command -v "$(SKILL_EVALUATOR)")"; \
+		echo "skillevaluator: $$skill_evaluator_path"; \
+		"$$skill_evaluator_path" --version
+
+skill-evaluator-validate: skill-evaluator-check
+	@skill_evaluator_path="$$(command -v "$(SKILL_EVALUATOR)")"; \
+		"$$skill_evaluator_path" validate skills \
+		$(SKILL_EVALUATOR_FLAGS) \
+		-r "$(SKILL_EVALUATOR_REPORTS)" \
+		-o "$(SKILL_EVALUATOR_OUT)"
+
+validate-skills-external: skill-evaluator-validate
+
 nv-base-check:
-	@if ! command -v "$(NV_BASE)" >/dev/null 2>&1; then \
-		echo "nv-base command not found: $(NV_BASE)"; \
-		echo "Install/activate nv-base, or run:"; \
-		echo "  make nv-base-validate NV_BASE=/path/to/nv-base"; \
-		exit 127; \
-	fi
-	@nv_base_path="$$(command -v "$(NV_BASE)")"; \
-	nv_base_bin="$$(dirname "$$nv_base_path")"; \
-	echo "nv-base: $$nv_base_path"; \
-	if PATH="$$nv_base_bin:$$PATH" command -v skillspector >/dev/null 2>&1; then \
-		echo "skillspector: $$(PATH="$$nv_base_bin:$$PATH" command -v skillspector)"; \
-	elif [ "$(NV_BASE_REQUIRE_SKILLSPECTOR)" = "1" ]; then \
-		echo "skillspector command not found in nv-base environment"; \
-		echo "Install it into the same environment as nv-base, for example:"; \
-		echo "  $$nv_base_bin/python -m pip install 'git+https://gitlab-master.nvidia.com/demos/skillspector.git'"; \
-		exit 127; \
-	else \
-		echo "warning: skillspector command not found; NV-base will skip security scan"; \
-	fi
+	@echo "warning: nv-base-check is deprecated; use skill-evaluator-check" >&2
+	@$(MAKE) --no-print-directory skill-evaluator-check
 
-nv-base-validate: nv-base-check
-	@nv_base_path="$$(command -v "$(NV_BASE)")"; \
-	nv_base_bin="$$(dirname "$$nv_base_path")"; \
-	PATH="$$nv_base_bin:$$PATH" "$$nv_base_path" validate skills -r cli json -o "$(NV_BASE_OUT)" --catalog-path "$(CURDIR)" $(NV_BASE_FLAGS)
+nv-base-validate:
+	@echo "warning: nv-base-validate is deprecated; use skill-evaluator-validate" >&2
+	@$(MAKE) --no-print-directory skill-evaluator-validate
 
-validate-skills-internal: nv-base-validate
+validate-skills-internal:
+	@echo "warning: validate-skills-internal is deprecated; use validate-skills-external" >&2
+	@$(MAKE) --no-print-directory skill-evaluator-validate
 
 list-skills:
 	$(PYTHON) -m eval_engine.list_skills --out SKILL_INDEX.md

--- a/Makefile
+++ b/Makefile
@@ -37,12 +37,10 @@ AUDIT_OUT ?= runs/audit_$(SKILL)
 ACTION ?=
 SKILL_EVALUATOR ?= skillevaluator
 SKILL_EVALUATOR_OUT ?= /tmp/medical-AI-skills-skillevaluator
-SKILL_EVALUATOR_REPORTS ?= json,markdown
-SKILL_EVALUATOR_FLAGS ?= --external --no-dedup -c --min-score 70
 
 WORKFLOW_CT_SEG ?= examples/workflows/ct_dicom_to_segmentation_evidence.yaml
 WORKFLOW_CT_SEG_OUT ?= runs/ct_dicom_seg_evidence
-.PHONY: help help-run help-author help-trust help-study help-all run-skill run-llm-skill run-workflow run-workflow-ct-seg run-benchmark run-trusted diff lint test verify verify-skills verify-reproducibility verify-negative-fixtures verify-with-vs-without audit-with-vs-without preflight-with-vs-without transfer-manifest-with-vs-without approval-packet-with-vs-without approved-rerun-plan-with-vs-without invariants-with-vs-without check-invariants-with-vs-without status-agent-skills prove-agent-skills prove-with-vs-without plan-with-vs-without study skill-evaluator-check skill-evaluator-validate validate-skills-external nv-base-check nv-base-validate validate-skills-internal list-skills compare-skills audit-skill clean-runs validate-pack review-packet validate-skill bench-matrix copyright copyright-check
+.PHONY: help help-run help-author help-trust help-study help-all run-skill run-llm-skill run-workflow run-workflow-ct-seg run-benchmark run-trusted diff lint test verify verify-skills verify-reproducibility verify-negative-fixtures verify-with-vs-without audit-with-vs-without preflight-with-vs-without transfer-manifest-with-vs-without approval-packet-with-vs-without approved-rerun-plan-with-vs-without invariants-with-vs-without check-invariants-with-vs-without status-agent-skills prove-agent-skills prove-with-vs-without plan-with-vs-without study skill-evaluator-validate list-skills compare-skills audit-skill clean-runs validate-pack review-packet validate-skill bench-matrix copyright copyright-check
 
 help:
 	@echo "Targets:"
@@ -50,7 +48,7 @@ help:
 	@echo "  help-author   skill authoring, catalog validation, and repo checks"
 	@echo "  help-trust    evidence-pack, verifier, and trust commands"
 	@echo "  help-study    with-vs-without study maintenance"
-	@echo "  help-all      every target, including compatibility aliases"
+	@echo "  help-all      complete target list"
 	@echo ""
 	@echo "Common:"
 	@echo "  make list-skills"
@@ -73,7 +71,7 @@ help-all:
 	@echo "  help-author                                             skill authoring, catalog validation, and repo checks"
 	@echo "  help-trust                                              evidence-pack, verifier, and trust commands"
 	@echo "  help-study                                              with-vs-without study maintenance"
-	@echo "  help-all                                                every target, including compatibility aliases"
+	@echo "  help-all                                                complete target list"
 	@echo "  --- Discover ---"
 	@echo "  list-skills                                             regenerate SKILL_INDEX.md"
 	@echo "  --- Run ---"
@@ -88,9 +86,7 @@ help-all:
 	@echo "  validate-skill SCENARIO=<path> [VALIDATE_SKILL_OUT=<dir>]   paired with/without skill behavior eval (v0: mock backend)"
 	@echo "  verify-skills                                           audit every skill/verifier + repeat reproducibility checks"
 	@echo "  verify-reproducibility                                  run manifest-declared repeat/preflight reproducibility audit"
-	@echo "  skill-evaluator-check                                   verify the public skillevaluator CLI is available"
 	@echo "  skill-evaluator-validate [SKILL_EVALUATOR=/path/to/skillevaluator]   run the public external publication preflight"
-	@echo "  validate-skills-external                                alias for skill-evaluator-validate"
 	@echo "  --- Trust ---"
 	@echo "  verify                                                  smoke-test evidence harness (lint + canonical pack diff)"
 	@echo "  verify-negative-fixtures                                run every manifest-declared negative fixture"
@@ -118,10 +114,6 @@ help-all:
 	@echo "  lint                                                    structural + doc lints"
 	@echo "  test                                                    pytest (eval_engine + skills + verifiers + with-vs-without harness)"
 	@echo "  clean-runs                                              remove local generated runs"
-	@echo "  --- Deprecated compatibility aliases ---"
-	@echo "  nv-base-check                                           deprecated alias for skill-evaluator-check"
-	@echo "  nv-base-validate                                        deprecated alias for skill-evaluator-validate"
-	@echo "  validate-skills-internal                                deprecated alias for skill-evaluator-validate"
 
 help-run:
 	@echo "Run targets:"
@@ -138,10 +130,7 @@ help-author:
 	@echo "  validate-skill SCENARIO=<path> [VALIDATE_SKILL_OUT=<dir>]   paired with/without skill behavior eval (v0: mock backend)"
 	@echo "  verify-skills                                           audit every skill/verifier + repeat reproducibility checks"
 	@echo "  verify-reproducibility                                  run manifest-declared repeat/preflight reproducibility audit"
-	@echo "  skill-evaluator-check                                   verify the public skillevaluator CLI is available"
 	@echo "  skill-evaluator-validate [SKILL_EVALUATOR=/path/to/skillevaluator]   run the public external publication preflight"
-	@echo "  validate-skills-external                                alias for skill-evaluator-validate"
-	@echo "  nv-base-validate                                        deprecated compatibility alias"
 	@echo "  list-skills                                             regenerate SKILL_INDEX.md"
 	@echo "  lint                                                    structural + doc lints"
 	@echo "  test                                                    pytest (eval_engine + skills + verifiers + with-vs-without harness)"
@@ -314,7 +303,7 @@ prove-with-vs-without:
 plan-with-vs-without:
 	@$(PYTHON) tools/with_vs_without/audit_nv_model_studies.py --format commands
 
-skill-evaluator-check:
+skill-evaluator-validate:
 	@if ! command -v "$(SKILL_EVALUATOR)" >/dev/null 2>&1; then \
 		echo "skillevaluator command not found: $(SKILL_EVALUATOR)"; \
 		echo "Install the public release (https://docs.nvidia.com/skills/skillevaluator/installation), or run:"; \
@@ -323,28 +312,11 @@ skill-evaluator-check:
 	fi
 	@skill_evaluator_path="$$(command -v "$(SKILL_EVALUATOR)")"; \
 		echo "skillevaluator: $$skill_evaluator_path"; \
-		"$$skill_evaluator_path" --version
-
-skill-evaluator-validate: skill-evaluator-check
-	@skill_evaluator_path="$$(command -v "$(SKILL_EVALUATOR)")"; \
+		"$$skill_evaluator_path" --version && \
 		"$$skill_evaluator_path" validate skills \
-		$(SKILL_EVALUATOR_FLAGS) \
-		-r "$(SKILL_EVALUATOR_REPORTS)" \
+		--external --no-dedup -c --min-score 70 \
+		-r json,markdown \
 		-o "$(SKILL_EVALUATOR_OUT)"
-
-validate-skills-external: skill-evaluator-validate
-
-nv-base-check:
-	@echo "warning: nv-base-check is deprecated; use skill-evaluator-check" >&2
-	@$(MAKE) --no-print-directory skill-evaluator-check
-
-nv-base-validate:
-	@echo "warning: nv-base-validate is deprecated; use skill-evaluator-validate" >&2
-	@$(MAKE) --no-print-directory skill-evaluator-validate
-
-validate-skills-internal:
-	@echo "warning: validate-skills-internal is deprecated; use validate-skills-external" >&2
-	@$(MAKE) --no-print-directory skill-evaluator-validate
 
 list-skills:
 	$(PYTHON) -m eval_engine.list_skills --out SKILL_INDEX.md

--- a/docs/authoring-skills.md
+++ b/docs/authoring-skills.md
@@ -96,10 +96,13 @@ skills/<name>/
    too large or otherwise prohibited from git, record that as an explicit gap
    rather than promoting the pack as a complete trusted pass.
 
-## Internal NV-BASE profile
+## SkillEvaluator publication preflight
 
-The local/internal validation profile is intentionally stricter than the base
-Agent Skills spec. Before opening a PR, make the skill friendly to that check:
+The public SkillEvaluator `external` profile adds publication checks beyond the
+base Agent Skills spec. Before opening a PR, make the skill friendly to that
+check. Follow the public
+[SkillEvaluator installation guide](https://docs.nvidia.com/skills/skillevaluator/installation)
+when the CLI is not already available:
 
 - Use kebab-case for both `skills/<name>/` and frontmatter `name`.
 - Keep `description` concise, usually under 200 characters. Include both a
@@ -135,7 +138,7 @@ not emit the needed signal.
 ## Check before PR
 
 ```bash
-make nv-base-validate
+make skill-evaluator-validate
 make list-skills
 make verify-skills
 make run-skill SKILL=<name> FIXTURE=<fixture> OUT=runs/<name>_smoke
@@ -144,12 +147,18 @@ make verify
 
 Record intentional gaps under the manifest's `limitations` field.
 
-If `nv-base` is installed in a local virtualenv rather than on `PATH`, pass it
-explicitly:
+If `skillevaluator` is installed in a local environment rather than on `PATH`,
+pass it explicitly:
 
 ```bash
-make nv-base-validate NV_BASE=/path/to/nv-base
+make skill-evaluator-validate \
+  SKILL_EVALUATOR=/path/to/skillevaluator
 ```
+
+This runs the public external preflight with Tier 2 disabled, complete
+collection reporting, and a quality threshold of 70. Central NVSkills CI may
+use a newer managed SkillEvaluator build, agent runtimes, and gate policy, so a
+local pass does not replace the managed PR check.
 
 ## Related
 

--- a/docs/authoring-skills.md
+++ b/docs/authoring-skills.md
@@ -156,9 +156,11 @@ make skill-evaluator-validate \
 ```
 
 This runs the public external preflight with Tier 2 disabled, complete
-collection reporting, and a quality threshold of 70. Central NVSkills CI may
-use a newer managed SkillEvaluator build, agent runtimes, and gate policy, so a
-local pass does not replace the managed PR check.
+collection reporting, a quality threshold of 70, and JSON/Markdown reports in
+`/tmp/medical-AI-skills-skillevaluator`. Override the report directory with
+`SKILL_EVALUATOR_OUT=<path>`. Central NVSkills CI may use a newer managed
+SkillEvaluator build, agent runtimes, and gate policy, so a local pass does not
+replace the managed PR check.
 
 ## Related
 

--- a/docs/release-readiness.md
+++ b/docs/release-readiness.md
@@ -21,9 +21,10 @@ human review, and repo validation all line up:
   verifier coverage, provenance gaps, trace digest, artifacts, and limitations
   are readable without opening every JSON file first.
 - Repo validation: `make verify-skills` passes. With-vs-without checks pass when
-  the skill is part of that backend comparison story. `make nv-base-validate`
-  should pass in an NV-BASE environment when the release depends on that
-  internal profile, or the unavailable profile is recorded as a release gap.
+  the skill is part of that backend comparison story.
+  `make skill-evaluator-validate` should pass with the public SkillEvaluator
+  external profile, or the unavailable preflight is recorded as a release gap.
+  Managed NVSkills CI remains a separate PR gate.
 
 ## Snapshot command
 
@@ -66,9 +67,10 @@ Evidence from the local readiness run:
 - Pending external LLM calls: 0. Maximum possible repair calls: 0.
 - Reviewed with-vs-without payload fingerprint:
   `a226c31aefa65f97a760ee97f3d90560ecda10cd409aed24fe8f4712d1354143`.
-- NV-BASE is not part of this no-network snapshot. Run
-  `make nv-base-validate` in an NV-BASE environment before claiming internal
-  profile readiness.
+- SkillEvaluator is not part of this historical no-network snapshot. Run
+  `make skill-evaluator-validate` with the public tool before claiming external
+  publication-preflight readiness; do not present it as a managed NVSkills CI
+  result.
 
 There are no top lifecycle blockers in this snapshot. Review priority therefore
 moves from blocker cleanup to release-claim review and evidence-boundary review.

--- a/docs/skill-authoring-best-practices.md
+++ b/docs/skill-authoring-best-practices.md
@@ -25,7 +25,7 @@ catalog entries. Sections below apply to both unless noted.
 - [Upstream fidelity and reference baselines](#upstream-fidelity-and-reference-baselines)
 - [Workflows and feedback loops](#workflows-and-feedback-loops)
 - [Scripts: solve, don't punt](#scripts-solve-dont-punt)
-- [Internal NV-BASE profile](#internal-nv-base-profile)
+- [SkillEvaluator publication preflight](#skillevaluator-publication-preflight)
 - [Anti-patterns](#anti-patterns)
 - [Where checks belong](#where-checks-belong)
 - [Authoring checklist](#authoring-checklist)
@@ -180,10 +180,10 @@ skills/<name>/
 - **Bundle large reference material freely** — files that aren't read don't
   cost tokens. The penalty is only paid on read.
 
-### Internal quality section pattern
+### Publication quality section pattern
 
-The internal NV-BASE quality profile expects SKILL.md to be immediately useful
-to an agent. Include this shape near the top of every skill body:
+The SkillEvaluator publication profile expects SKILL.md to be immediately
+useful to an agent. Include this shape near the top of every skill body:
 
 ```markdown
 ## Purpose
@@ -395,23 +395,28 @@ def load_volume(path):
 - **Reference the script's output schema** from the manifest when the output
   is gated. See [`spec/skill_manifest.schema.json`](../spec/skill_manifest.schema.json).
 
-## Internal NV-BASE profile
+## SkillEvaluator publication preflight
 
-Run the same local profile used for this repo before asking for review:
-
-```bash
-make nv-base-validate
-```
-
-The Makefile defaults to `NV_BASE=nv-base`, writes reports under
-`/tmp/medical-AI-skills-nvbase`, and passes `--no-dedup -c` for local no-key
-validation. If `nv-base` lives in a local virtualenv, pass it explicitly:
+Run the repository's public external preflight before asking for review:
 
 ```bash
-make nv-base-validate NV_BASE=/path/to/nv-base
+make skill-evaluator-validate
 ```
 
-Internal CI may run the same validator without the local `--no-dedup` flag.
+The Makefile defaults to `SKILL_EVALUATOR=skillevaluator`, writes JSON and
+Markdown reports under `/tmp/medical-AI-skills-skillevaluator`, and applies
+`--external --no-dedup -c --min-score 70`. If `skillevaluator` lives in a
+local environment, pass it explicitly:
+
+```bash
+make skill-evaluator-validate \
+  SKILL_EVALUATOR=/path/to/skillevaluator
+```
+
+The command follows public SkillEvaluator's external CI gate. Managed NVSkills
+CI may use a newer internal build, agent runtimes, and an independent gate
+policy; a local pass is useful preflight evidence, not a substitute for the PR
+check.
 
 Keep these checks clean:
 

--- a/docs/skill-authoring-best-practices.md
+++ b/docs/skill-authoring-best-practices.md
@@ -403,20 +403,10 @@ Run the repository's public external preflight before asking for review:
 make skill-evaluator-validate
 ```
 
-The Makefile defaults to `SKILL_EVALUATOR=skillevaluator`, writes JSON and
-Markdown reports under `/tmp/medical-AI-skills-skillevaluator`, and applies
-`--external --no-dedup -c --min-score 70`. If `skillevaluator` lives in a
-local environment, pass it explicitly:
-
-```bash
-make skill-evaluator-validate \
-  SKILL_EVALUATOR=/path/to/skillevaluator
-```
-
-The command follows public SkillEvaluator's external CI gate. Managed NVSkills
-CI may use a newer internal build, agent runtimes, and an independent gate
-policy; a local pass is useful preflight evidence, not a substitute for the PR
-check.
+The command follows public SkillEvaluator's external CI gate. Installation,
+overrides, report location, and the boundary with managed NVSkills CI are
+documented once in
+[`authoring-skills.md`](authoring-skills.md#skillevaluator-publication-preflight).
 
 Keep these checks clean:
 


### PR DESCRIPTION
## Summary

- replace the retired NV-BASE local validation path with the public
  SkillEvaluator external preflight
- expose one canonical `make skill-evaluator-validate` target and remove
  deprecated or redundant aliases
- consolidate authoring and release-readiness guidance around the public
  preflight
- keep managed NVSkills CI documented as an independent PR gate

## Why

NVIDIA has released SkillEvaluator publicly, while this repository still
described and invoked the earlier private NV-BASE integration. The compatibility
layer added during migration also left several equivalent Make targets and
duplicated configuration surfaces.

This change makes the public external preflight the sole local publication
command. It does not modify `.github/workflows/request-nvskills-ci.yml`, whose
current permission shape already matches the managed bridge requirements.

## User impact

Contributors now run:

```bash
make skill-evaluator-validate
```

The target uses the public external profile with Tier 2 disabled, complete
collection reporting, a quality threshold of 70, and JSON/Markdown output. A
custom executable or report directory can still be supplied through
`SKILL_EVALUATOR` and `SKILL_EVALUATOR_OUT`.

## Validation

- `make test`: 421 passed
- `make verify-skills`: 21/21 real specs passed and 21/21 reproducibility
  audits passed
- `python -m eval_engine.lint_repo`: 0 warnings, 0 errors
- focused pre-commit hooks for all changed files: passed
- evidence-pack smoke and canonical diff: passed with 0 gate or payload drift
- Make target plumbing smoke: passed
- removed aliases: confirmed unavailable

The public `skillevaluator` executable is not installed in the local
environment, so the real external preflight was not run locally. The aggregate
all-files `make lint` also stalls in the existing Black hook in this sandbox;
all changed-file hooks and the other all-files hooks completed successfully.
Managed `/nvskills-ci` remains the authoritative integration check for this PR.

AI-assisted: Created with Codex/GPT at the user's request.
