### PR TITLE
Document agent-assisted contribution workflow

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,6 +5,135 @@ with their own data and environment. It also accepts skill-shaped **verifiers**
 and supporting harness changes. It does not accept generic agent evaluators,
 clinical claims, or homegrown reimplementations of upstream inference.
 
+## Quick contribution workflow
+
+Use these steps to take an agent-assisted change from an idea to a pull
+request. For skill-specific detail, follow
+[`docs/authoring-skills.md`](docs/authoring-skills.md).
+
+### Roles
+
+- An agent may research, author all source-controlled skill components and
+  evals, run local checks, diagnose source failures, and draft the submission.
+- The contributing engineer defines the intended behavior and reviews the
+  actual diff, fixtures, eval expectations, outputs, dependencies, side
+  effects, provenance, and limitations.
+- A maintainer handles repository access, `/nvskills-ci`, managed-service
+  failures, merge approval, and catalog publication.
+
+### 1. Clone and create a source-repository branch
+
+Start from `dev`:
+
+```bash
+git clone https://github.com/NVIDIA-Medtech/medical-AI-skills.git
+cd medical-AI-skills
+git switch dev
+git pull --ff-only origin dev
+git switch -c <github-user>/<short-topic>
+```
+
+In a fresh clone, the source-repository remote is `origin`. For an existing
+checkout, skip the first two commands, use `git remote -v` to identify the
+remote that points to `NVIDIA-Medtech/medical-AI-skills`, and call it
+`<source-remote>` below. Replace `origin` in the pull command when necessary.
+Pushing requires source-repository write access; ask a maintainer if access is
+missing or `git push` is denied.
+
+Changes under `skills/` require NVSkills CI. Its managed signing flow currently
+requires the pull request head to be a source-repository branch, so a fork pull
+request is not a workaround. See the public
+[`NVIDIA/skills` required-status workflow](https://github.com/NVIDIA/skills/blob/main/.github/workflows/require-nvskills-status.yml).
+
+### 2. Define and author the contribution
+
+An agent may write the skill documentation, manifest, wrapper, schema,
+synthetic fixtures, tests, `evals/evals.json`, and scenario YAML. The engineer
+confirms the medtech task, upstream tool and documented entry point, expected
+inputs and outputs, important failure modes, fixture safety and provenance,
+dependencies, side effects, non-goals, and any licensing or IP implications.
+
+Maintainer approval is not required to begin. Ask for early feedback only when
+catalog fit, a clinical boundary, licensing, or a shared schema or
+`eval_engine` change is unclear.
+
+Do not create or edit `BENCHMARK.md`, `skill-card.md`, or `skill.oms.sig`;
+NVSkills CI generates or refreshes these publication artifacts.
+
+### 3. Validate locally and review the result
+
+Run the exact command in `SKILL.md` against the smallest safe fixture. Then use
+the applicable focused checks:
+
+```bash
+make run-skill SKILL=<name> FIXTURE=<fixture> OUT=runs/<name>_smoke
+make validate-skill SCENARIO=skills/<name>/evals/<scenario>.yaml
+make audit-skill SKILL=<name>
+make skill-evaluator-validate
+```
+
+Keep generated output under `runs/`. Finish with the repository checks in
+[Run before submitting](#run-before-submitting).
+
+The engineer reviews the actual code, input, and output—not only an agent
+summary—and confirms:
+
+- the documented upstream interface is used and failure cases fail clearly
+- output matches its schema, artifacts exist, and eval expectations are sound
+- fixtures contain no patient data, secrets, local paths, weights, or large
+  medical volumes
+- `SKILL.md`, the manifest, runtime behavior, dependencies, side effects,
+  provenance, claims, and limitations agree
+
+For GPU, model, Docker, dataset, or external-service requirements, the engineer
+arranges or supervises an approved integration smoke test and records what was
+and was not tested in the pull request.
+
+### 4. Sign off, push, and open the pull request
+
+An agent may prepare these commands when requested, but the engineer must
+inspect the staged diff and authorize the DCO sign-off:
+
+```bash
+git add <intended-files>
+git diff --cached
+git commit -s -m "Add <skill or change>"
+git push -u <source-remote> <github-user>/<short-topic>
+```
+
+Open the pull request against `dev`. State the purpose and upstream tool,
+fixture provenance, dependency or licensing changes, commands and results,
+unavailable checks, and known limitations. See [Signing your work](#signing-your-work)
+for the DCO policy.
+
+### 5. Let the maintainer run NVSkills CI
+
+After review feedback is resolved and skill content is stable, a maintainer or
+administrator comments:
+
+```text
+/nvskills-ci
+```
+
+`make skill-evaluator-validate` is a local preflight; it does not reproduce or
+replace the managed evaluation and signing service. When NVSkills CI finishes,
+the engineer reviews `BENCHMARK.md` and `skill-card.md`, and the maintainer
+confirms the generated-only diff, successful status, and `skill.oms.sig`.
+Neither edits the generated artifacts directly.
+
+If a failure points to source, manifests, evals, or fixtures, reproduce and fix
+it locally before a maintainer reruns `/nvskills-ci`. The maintainer handles
+dispatch, permission, service, signing, or non-reproducible failures. Rerun
+managed CI after any later skill-content change.
+
+### 6. Merge and publish
+
+The maintainer merges after engineer review, repository checks, and managed
+validation pass. A new skill also needs an explicit entry in
+[`NVIDIA/skills`' Medical AI component](https://github.com/NVIDIA/skills/blob/main/components.d/medical-ai-skills.yml),
+which the maintainer owns. Adding the source directory alone does not publish
+the skill in the catalog.
+
 ## Where to put work
 
 ```text

--- a/docs/agentskills-adoption.md
+++ b/docs/agentskills-adoption.md
@@ -67,18 +67,19 @@ Current authored examples:
 | `dicom_series_preflight` | A1 onboarding; agent must use the gates to make a go/no-go call, not bypass them |
 
 Legacy GPU/Docker skills may still rely on `fixtures/` + manifest gates until
-their external-publication pass adds prompt evals and `BENCHMARK.md`. Treat
-that as publication work, not a reason to skip the format for new skills.
+their external-publication pass adds prompt evals. NVSkills CI generates the
+corresponding `BENCHMARK.md`; this gap is not a reason to skip the eval format
+for new skills.
 
 ### 4. with_skill vs without_skill baseline framing
 
 Each `evals.json` carries a `baseline_methodology` block describing what
 running the test case looks like *with* the skill installed vs *without* it.
-`BENCHMARK.md` is the publication-facing report for those results: agents
-tested, task completion, quality notes, token/time cost where available, and
-remaining gaps. Running the baseline is an authoring-time task (run the agent
-twice, grade both); the Medical AI Skills evidence harness remains the domain-gate
-path.
+`BENCHMARK.md` is the managed publication-facing report for those results:
+agents tested, task completion, quality notes, token/time cost where available,
+and remaining gaps. Contributors prepare and review the eval inputs; NVSkills
+CI runs the publication baseline and generates the report. The Medical AI
+Skills evidence harness remains the local domain-gate path.
 
 ## What We Deliberately Keep Internal
 

--- a/docs/authoring-skills.md
+++ b/docs/authoring-skills.md
@@ -52,9 +52,13 @@ skills/<name>/
   validators/output_schema.json   # when output JSON is gated
   fixtures/                # small synthetic/public inputs
   evals/evals.json         # prompt-shaped skill-behavior evals for publication
-  BENCHMARK.md             # with-skill / without-skill results for publication
   tests/                   # optional but encouraged for wrapper internals
 ```
+
+NVSkills CI generates or refreshes the publication artifacts `BENCHMARK.md`,
+`skill-card.md`, and `skill.oms.sig` after the pull-request source is stable.
+Do not create or edit them manually. For an existing skill, leave its current
+generated artifacts unchanged while authoring; managed CI will replace them.
 
 ## Authoring order
 
@@ -84,10 +88,7 @@ skills/<name>/
    prompts, expected skill/script use, and scope assertions. GPU-heavy skills
    may use command-shape or preflight evals when full inference is not suitable
    for an agent harness.
-6. **Benchmark report** — add `BENCHMARK.md` summarizing with-skill and
-   without-skill behavior, agents tested, task completion, token/time cost, and
-   any remaining gaps.
-7. **Evidence** — run locally, render a review packet, then promote a small
+6. **Evidence** — run locally, render a review packet, then promote a small
    pass pack to `examples/` if it should be a regression anchor. Wrapper output
    should include concrete artifact paths, runtime facts, and limitations that
    make the review packet useful without requiring a reviewer to read every JSON

--- a/docs/skill-authoring-best-practices.md
+++ b/docs/skill-authoring-best-practices.md
@@ -161,7 +161,7 @@ skills/<name>/
   validators/           # output_schema.json (gated by manifest)
   fixtures/             # small synthetic/public inputs
   evals/evals.json      # prompt-shaped behavior evals for publication
-  BENCHMARK.md          # with-skill / without-skill result summary
+  BENCHMARK.md          # managed with-skill / without-skill result summary
   tests/                # focused parsing or invariant tests
   REFERENCE.md          # optional — deeper details, one level deep
   EXAMPLES.md           # optional — input/output pairs
@@ -525,8 +525,8 @@ Before merging a new or modified skill, verify:
   `.codex/skills/`, `.cursor/skills/`, or another agent-specific primary path
 - [ ] Directory name matches `name:` for externally published skills
 - [ ] `evals/evals.json` includes positive and negative trigger cases
-- [ ] `BENCHMARK.md` summarizes with-skill and without-skill results, tokens or
-  time where available, and remaining gaps
+- [ ] Managed NVSkills CI has generated `BENCHMARK.md`, `skill-card.md`, and
+  `skill.oms.sig` for the final source
 
 Run before submitting:
 


### PR DESCRIPTION
## Summary

- Add a concise six-step workflow from source-repository branch setup through catalog publication.
- Clarify what an agent may author and what the contributing engineer and maintainer must review.
- Document source-repository access, fork limitations, and explicit source-remote selection.
- Separate the local SkillEvaluator preflight from maintainer-triggered NVSkills CI.
- Align authoring documentation so managed benchmark, skill-card, and signature artifacts are not edited manually.

## Validation

- `make lint`
- `make test` (421 passed)
- `make verify`
- `make verify-skills`
- `make verify-negative-fixtures`

`make list-skills` was also run. It exposed unrelated existing `nv-segment-ct` index drift, which is intentionally excluded from this documentation-only PR.

No files under `skills/` are changed, so a managed `/nvskills-ci` evaluation is not requested for this PR.

AI-assisted: Created with Codex/GPT at the user's request.